### PR TITLE
Fixed ListContinuousAsync Task.Result() comment

### DIFF
--- a/projections/manager.go
+++ b/projections/manager.go
@@ -101,7 +101,7 @@ func (m *Manager) ListOneTimeAsync(userCredentials *cli.UserCredentials) *tasks.
 	return m.client.ListOneTime(m.httpEndpoint, userCredentials)
 }
 
-// Task.Result() returns []projections.ProjectionDetails
+// Task.Result() returns []*projections.ProjectionDetails
 func (m *Manager) ListContinuousAsync(userCredentials *cli.UserCredentials) *tasks.Task {
 	return m.client.ListContinuous(m.httpEndpoint, userCredentials)
 }


### PR DESCRIPTION
ListContinuousAsync Task.Result() returns array of pointer instead